### PR TITLE
Make shared and releases directories configurable

### DIFF
--- a/manifests/deploytarget.pp
+++ b/manifests/deploytarget.pp
@@ -7,9 +7,9 @@ define capistrano::deploytarget (
 	$shared_dirs 	= $capistrano::shared_dirs,
 	$symlink_shared_system_dirs = $capistrano::symlink_shared_system_dirs,
 	$cap_version = $capistrano::cap_version,
+	$shared_dir 	= sprintf($capistrano::shared_dir_spf, $title),
+	$releases_dir 	= sprintf($capistrano::releases_dir_spf, $title),
 ) {
-	$shared_dir 	= sprintf($capistrano::shared_dir_spf, $title)
-	$releases_dir 	= sprintf($capistrano::releases_dir_spf, $title)
 
 	ensure_resource('user',  $deploy_user, {
 		ensure => present,


### PR DESCRIPTION
Not sure if this is of any use, but in our deployment we needed to be able to specify our own values for the paths to the shared and release directories rather than using the defaults in /var/www.
